### PR TITLE
Replace GestureDetector with Listener for better performance when scrollers are involved.

### DIFF
--- a/lib/src/time-range-dialog.dart
+++ b/lib/src/time-range-dialog.dart
@@ -322,8 +322,8 @@ class _TimeRangePickerState extends State<_TimeRangePicker>
     return TimeOfDay(hour: hours, minute: minutes);
   }
 
-  void _panStart(DragStartDetails details) {
-    var globalPoint = details.globalPosition;
+  void _panStart(PointerDownEvent details) {
+    var globalPoint = details.position;
     var snap = widget.handlerRadius * 2.5;
     RenderBox circle = _circleKey.currentContext.findRenderObject();
 
@@ -368,11 +368,11 @@ class _TimeRangePickerState extends State<_TimeRangePicker>
     }
   }
 
-  void _panUpdate(DragUpdateDetails details) {
+  void _panUpdate(PointerMoveEvent details) {
     if (_activeTime == null) return;
     RenderBox circle = _circleKey.currentContext.findRenderObject();
     final center = circle.size.center(Offset.zero);
-    final point = circle.globalToLocal(details.globalPosition);
+    final point = circle.globalToLocal(details.position);
     final touchPositionFromCenter = point - center;
     var dir = normalizeAngle(touchPositionFromCenter.direction);
 
@@ -424,7 +424,7 @@ class _TimeRangePickerState extends State<_TimeRangePicker>
         normalisedTarget <= normalisedMax;
   }
 
-  void _panEnd(DragEndDetails details) {
+  void _panEnd(dynamic event) {
     setState(() {
       _activeTime = null;
     });
@@ -531,10 +531,11 @@ class _TimeRangePickerState extends State<_TimeRangePicker>
   Widget _buildTimeRange(
           {@required MaterialLocalizations localizations,
           @required ThemeData themeData}) =>
-      GestureDetector(
-        onPanStart: _panStart,
-        onPanUpdate: _panUpdate,
-        onPanEnd: _panEnd,
+      Listener(
+        onPointerDown: _panStart,
+        onPointerMove: _panUpdate,
+        onPointerUp: _panEnd,
+        onPointerCancel: _panEnd,
         child: AspectRatio(
           aspectRatio: 1,
           child: Container(


### PR DESCRIPTION
In my application I need to put the widget into a vertically scrollable area. This causes an issue where drag events on picker seem to get delayed due to `GestureArena` showdown between the `ListView` and the picker.

Thus the coordinates received by the `_panStart` method sometimes get delayed and the delayed coordinates result in picker not being able to figure out which handler got touched, leading to a gesture not being claimed. Ultimately resulting in no handler movement.

I replaced the GestureDetector with a Listener which improves the responsiveness.