### PR TITLE
Fixed the issue explained below.

### DIFF
--- a/lib/src/time-range-dialog.dart
+++ b/lib/src/time-range-dialog.dart
@@ -357,6 +357,10 @@ class _TimeRangePickerState extends State<TimeRangePicker>
 
     int hours = (roundedMin / 60).floor();
     int minutes = (roundedMin % 60).round();
+    if (hours > 23) // To fix for hour values bigger than 23:59!
+    {
+      hours -= 24;
+    } /* else not needed */
     return TimeOfDay(hour: hours, minute: minutes);
   }
 


### PR DESCRIPTION
While using the max duration feature, if we set the end time earlier than the start time when the start time is close to '00:00', the time range picker was calculating the hour like 43:20, 33:45, etc.
Warning: Not tested for other usage scenarios.