### PR TITLE
Fix: Add margin to Container to further separate the circle

### DIFF
--- a/lib/src/time-range-dialog.dart
+++ b/lib/src/time-range-dialog.dart
@@ -759,6 +759,7 @@ class TimeRangePickerState extends State<TimeRangePicker>
     return Container(
       color: backgroundColor,
       padding: EdgeInsets.all(24),
+      margin: EdgeInsets.only(bottom: 24),
       child: Flex(
         direction: landscape ? Axis.vertical : Axis.horizontal,
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,


### PR DESCRIPTION
The circle is too close together.

BEFORE:
![image](https://github.com/Chris1234567899/flutter_time_range_picker/assets/16550103/9293cafc-3388-41ca-909f-f3893f3c4f53)

AFTER:
![image](https://github.com/Chris1234567899/flutter_time_range_picker/assets/16550103/65c63e13-62fc-4280-8e35-a799164d623f)